### PR TITLE
github:  add github push event handling

### DIFF
--- a/example.conf
+++ b/example.conf
@@ -28,3 +28,12 @@ linker:
     user_token: <user_token>
     user_secret: <user_secret>
 
+github:
+    # Port to listen on for github webhook events
+    listen_port: <port>
+
+    # Map of repository names to channels.  Each channel has a
+    # list of github webhook events that should be sent to the channel.
+    repos:
+        username/repo:
+            '#some-channel': ['push']

--- a/plugins/github.py
+++ b/plugins/github.py
@@ -1,11 +1,72 @@
+import json
+import weakref
+
 import requests
 from twisted.python import log
+
+from twisted.web import (server, resource, http)
+from twisted.internet import reactor
+
+class GithubHook(resource.Resource):
+    """
+    Web handler for github webhooks
+    """
+    isLeaf = True
+
+    def __init__(self):
+        resource.Resource.__init__(self)
+        self._push_handlers = weakref.WeakSet()
+
+    def register_push_handler(self, callback):
+        """
+        Register a handler for push events
+
+        @param callback - callback for push events.  The function should
+                          accept a dictionary which describes the event
+        """
+        self._push_handlers.add(callback)
+
+    def unregister_push_handler(self, callback):
+        """
+        Unregister a push event handler
+
+        @param callback - callback to unregister
+        """
+        self._push_handlers.remove(callback)
+
+    def render_POST(self, req):
+        event = req.getHeader('X-Github-Event')
+        if event is None:
+            return 'No X-Github-Event in header'
+
+        try:
+            data = json.loads(req.content.read())
+        except ValueError:
+            msg = 'Failed to parse data from %s' % (req.getClientIP(),)
+            log.err(msg)
+            return msg
+
+        try:
+            if event == 'push':
+                _ = [cb(data) for cb in self._push_handlers]
+        except Exception:
+            log.err()
+
+        return ''
 
 
 class Github(Plugin):
     def __init__(self, config={}):
         super(Github, self).__init__('github')
         self._config = config
+        self._hook = None
+        self._repos = self._config.get('repos', {})
+
+        if 'listen_port' in self._config:
+            handler = GithubHook()
+            handler.register_push_handler(self.handle_push)
+            site = server.Site(GithubHook())
+            reactor.listenTCP(self._config['listen_port'], site)
 
     @property
     def status(self):
@@ -27,6 +88,26 @@ class Github(Plugin):
             return '%s:  [%s] %s' % (
                 html.json()['created_on'], html.json()['status'], html.json()['body'])
 
+    @staticmethod
+    def shorten(url):
+        """
+        Shorten a github url
+
+        @param url  - full github url to shorten
+        @return     - shortened url
+        """
+        try:
+            req = requests.post('http://git.io/', data={'url': url})
+            req.raise_for_status()
+        except Exception, e:
+            log.err('Failed to git.io shorten %s: %s' % (url, str(e)))
+            return url
+
+        if req.status_code == 201 and 'location' in req.headers:
+            return req.headers['location']
+        else:
+            return url
+
     @irc_command('return current github status')
     def github(self, user, channel, args):
         if channel == self.nickname:
@@ -35,4 +116,57 @@ class Github(Plugin):
         else:
             self._proto.send_notice(channel, self.status)
 
+    def handle_push(self, data):
+        """
+        Handle github push events
+
+        @param data - dictionary describing the push event.
+        """
+        repo = '%s/%s' % (data['repository']['owner']['name'], data['repository']['name'])
+        if not repo in self._repos:
+            return
+
+        channels = [channel
+                for channel, events in self._repos[repo].items()
+                if 'push' in events]
+
+        if len(channels) == 0:
+            return
+
+        msgs = self._push_msgs(repo, data)
+
+        for channel in channels:
+            _ = [self._proto.send_notice(channel, msg) for msg in msgs]
+
+    def _push_msgs(self, repo, data):
+        """
+        Create messages from a push event for the given repo
+
+        @param repo - repository getting pushed to
+        @param data - dictionary describing push event
+        @return     - list of messages describing the push event
+        """
+        msgs = []
+        n_commits = len(data['commits'])
+
+        msgs.append('[%s] %s pushed %d commit%s to %s:' % (
+            repo,
+            data['pusher']['name'],
+            n_commits,
+            '' if n_commits <=1 else 's',
+            data['ref'].replace('refs/heads/', '')))
+
+        for commit in data['commits']:
+            header = commit['message'].split('\n', 1)[0]
+            if len(header) > 30:
+                swap_index = header.rindex(' ')
+                header = header[:swap_index] + ' ...'
+
+            msgs.append('    <%s> %s (%s)  %s' % (
+                commit['id'][:7],
+                header,
+                commit['author']['username'],
+                self.shorten(commit['url']),))
+
+        return msgs
 

--- a/test/github_test.py
+++ b/test/github_test.py
@@ -1,13 +1,120 @@
+import json
 import re
 import unittest
 
 import base
 
+commit_data = """
+{
+  "ref": "refs/heads/master",
+  "after": "a96dbcb0e566ba8330b2b24ce0f31ed53a29e0ff",
+  "before": "4a666d1d66e5db362742acee3c6fed4ca0b77a97",
+  "created": false,
+  "deleted": false,
+  "forced": false,
+  "compare": "https://github.com/jsbronder/test-hooks/compare/4a666d1d66e5...a96dbcb0e566",
+  "commits": [
+    {
+      "id": "a96dbcb0e566ba8330b2b24ce0f31ed53a29e0ff",
+      "distinct": true,
+      "message": "a commit message",
+      "timestamp": "2014-06-11T18:39:09-04:00",
+      "url": "https://github.com/jsbronder/test-hooks/commit/a96dbcb0e566ba8330b2b24ce0f31ed53a29e0ff",
+      "author": {
+        "name": "Justin Bronder",
+        "email": "jsbronder@gmail.com",
+        "username": "jsbronder"
+      },
+      "committer": {
+        "name": "Justin Bronder",
+        "email": "jsbronder@gmail.com",
+        "username": "jsbronder"
+      },
+      "added": [
+
+      ],
+      "removed": [
+
+      ],
+      "modified": [
+        "1"
+      ]
+    }
+  ],
+  "head_commit": {
+    "id": "a96dbcb0e566ba8330b2b24ce0f31ed53a29e0ff",
+    "distinct": true,
+    "message": "4",
+    "timestamp": "2014-06-11T18:39:09-04:00",
+    "url": "https://github.com/jsbronder/test-hooks/commit/a96dbcb0e566ba8330b2b24ce0f31ed53a29e0ff",
+    "author": {
+      "name": "Justin Bronder",
+      "email": "jsbronder@gmail.com",
+      "username": "jsbronder"
+    },
+    "committer": {
+      "name": "Justin Bronder",
+      "email": "jsbronder@gmail.com",
+      "username": "jsbronder"
+    },
+    "added": [
+
+    ],
+    "removed": [
+
+    ],
+    "modified": [
+      "1"
+    ]
+  },
+  "repository": {
+    "id": 20746319,
+    "name": "test-hooks",
+    "url": "https://github.com/jsbronder/test-hooks",
+    "description": "testing webhooks",
+    "watchers": 0,
+    "stargazers": 0,
+    "forks": 0,
+    "fork": false,
+    "size": 0,
+    "owner": {
+      "name": "jsbronder",
+      "email": "jsbronder@gmail.com"
+    },
+    "private": false,
+    "open_issues": 0,
+    "has_issues": true,
+    "has_downloads": true,
+    "has_wiki": true,
+    "created_at": 1402525177,
+    "pushed_at": 1402526351,
+    "master_branch": "master"
+  },
+  "pusher": {
+    "name": "jsbronder",
+    "email": "jsbronder@gmail.com"
+  }
+}
+"""
+
+
 class GithubTester(unittest.TestCase):
+    """
+    Test the github plugin without webhook configuration.
+    """
     def setUp(self):
-        self._plugin = base.load_plugin('github.py', 'Github')
+        config = {
+            'repos': {
+                'jsbronder/test-hooks': {
+                    base.TEST_CHANNEL: ['push']
+                },
+            },
+        }
+        self._plugin = base.load_plugin('github.py', 'Github', config=config)
+        self._plugin.shorten = lambda x : '<shorturl>'
         self._proto = base.TestProto([self._plugin])
         self._re = re.compile('^[0-9-]{10}T[0-9:]{8}Z:  \[[a-z]*\]')
+
 
     def test_query(self):
         m = self._plugin.status
@@ -17,6 +124,16 @@ class GithubTester(unittest.TestCase):
         self._proto.privmsg('tester', base.TEST_CHANNEL, '!github')
         self.assertEqual(1, len(self._proto.msgs))
         self.assertIsNotNone(self._re.search(self._proto.msgs[0][2]))
+
+    def test_webhook_push(self):
+        data = json.loads(commit_data) 
+        self._plugin.handle_push(data)
+        self.assertEqual(2, len(self._proto.msgs))
+        self.assertIn('pushed 1 commit to', self._proto.msgs[0][2])
+        self.assertIn('<shorturl>', self._proto.msgs[1][2])
+        self.assertIn('a commit message', self._proto.msgs[1][2])
+        self.assertIn('a96dbcb', self._proto.msgs[1][2])
+
 
 def main():
     unittest.main()


### PR DESCRIPTION
Add the ability to listen for github webhook events.  At the moment,
only push events are handled.  On this event, a short description of
each commit being pushed will be sent to interested channels.
